### PR TITLE
Fix for issue 9 Missing Style Definition for Layer MapServer 6.0

### DIFF
--- a/places.map
+++ b/places.map
@@ -13,6 +13,7 @@ LAYER
  CLASSITEM 'type'
 #if _display_capitals == 1
  CLASS
+STYLE END
   EXPRESSION ('[capital]'='1')
   LABEL
    FONT _capital_font
@@ -46,6 +47,7 @@ LAYER
 #endif
 #if _display_continents == 1
  CLASS
+STYLE END
   EXPRESSION 'continents'
   LABEL
    FONT _continent_font
@@ -63,6 +65,7 @@ LAYER
 #endif
 #if _display_countries == 1
  CLASS
+STYLE END
   EXPRESSION 'country'
   LABEL
    FONT _country_font
@@ -83,6 +86,7 @@ LAYER
 #endif
 #if _display_cities == 1
  CLASS
+STYLE END
   EXPRESSION 'city'
   LABEL
    FONT _city_font
@@ -111,6 +115,7 @@ LAYER
 #endif
 #if _display_towns == 1
  CLASS
+STYLE END
   EXPRESSION 'town'
   LABEL
    FONT _town_font
@@ -140,6 +145,7 @@ LAYER
 #endif
 #if _display_villages == 1
  CLASS
+STYLE END
   EXPRESSION 'village'
   LABEL
    FONT _village_font
@@ -168,6 +174,7 @@ LAYER
 #endif
 #if _display_hamlets == 1
  CLASS
+STYLE END
   EXPRESSION /suburb|hamlet|locality/
   LABEL
    FONT _hamlet_font


### PR DESCRIPTION
This is the small fix, it only adds STYLE END in each class in places.map. 
It doesn't seem to affect MapServer 6.2.
