### PR TITLE
Correct downloadlink and file for boundaries

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -21,14 +21,14 @@ TM_WORLD_BORDERS-0.3.shp: TM_WORLD_BORDERS-0.3.zip
 	touch TM_WORLD_BORDERS-0.3.shp
 
 10m_admin_0_boundary_lines_land.shp: 10m-admin-0-boundary-lines-land.zip
-	unzip 10m-admin-0-boundary-lines-land.zip
+	unzip ne_10m_admin_0_boundary_lines_land.zip
 	touch 10m_admin_0_boundary_lines_land.shp
 
 processed_p.tar.bz2:
 	wget http://tile.openstreetmap.org/processed_p.tar.bz2
 
 10m-admin-0-boundary-lines-land.zip:
-	wget http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/10m-admin-0-boundary-lines-land.zip
+	wget http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_admin_0_boundary_lines_land.zip
 
 shoreline_300.tar.bz2:
 	wget http://tile.openstreetmap.org/shoreline_300.tar.bz2


### PR DESCRIPTION
The boundaries link and file have changed at natural earth, breaking the make. This commit fixes that.
