### PR TITLE
Declare `data` `phony`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,5 +121,6 @@ boundaries.sql: boundaries.sql.in
 clean:
 	rm -f generated/*
 
+.PHONY: data
 data:
 	cd data; $(MAKE) $(MFLAGS)


### PR DESCRIPTION
Using `make data` from the `basemaps/` main dir does not do anything (`make: 'data' is up to date.`) because the `data` folder is already there after `git clone` and make thinks the job is done. `data` has to be declared as `.PHONY`: https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html to solve this.