### PR TITLE
Remove class `railway` from `roads_gen1`

### DIFF
--- a/imposm3-mapping.json
+++ b/imposm3-mapping.json
@@ -17,7 +17,7 @@
         },
         "roads_gen1": {
             "source": "roads",
-            "sql_filter": "type IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary', 'tertiary_link') OR class IN('railway')",
+            "sql_filter": "type IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary', 'tertiary_link')",
             "tolerance": 50.0
         },
 	"railways": {


### PR DESCRIPTION
As `railway` in basemaps uses its own tables these records are not needed in `roads_gen1` and can be removed.