### PR TITLE
Limit waterway-types in gen-tables

### DIFF
--- a/imposm3-mapping.json
+++ b/imposm3-mapping.json
@@ -37,12 +37,12 @@
 	},
         "waterways_gen0": {
             "source": "waterways_gen1",
-            "sql_filter": null,
+            "sql_filter": "type IN ('river', 'canal')",
             "tolerance": 200
         },
         "waterways_gen1": {
             "source": "waterways",
-            "sql_filter": null,
+            "sql_filter": "type IN ('river', 'canal', 'stream')",
             "tolerance": 50.0
         },
         "landusages_gen1": {


### PR DESCRIPTION
In comparison to [imposm-mapping.py](https://github.com/mapserver/basemaps/blob/master/imposm-mapping.py#L206) waterways in the imposm3 mapping additionally contain [waterway=ditch](https://wiki.openstreetmap.org/wiki/Tag:waterway%3Dditch) and [waterway=drain](https://wiki.openstreetmap.org/wiki/Tag:waterway%3Ddrain) in [imposm3-mapping.json](https://github.com/mapserver/basemaps/blob/master/imposm3-mapping.json#L452)

Those are not needed in the gen-tables and can be removed.