### PR TITLE
Add `wood` to `landusage_data` and align mapping of imposm3

### DIFF
--- a/generate_style.py
+++ b/generate_style.py
@@ -173,14 +173,14 @@ vars= {
       6:'"geometry from (select geometry ,osm_id, type, OSM_NAME_COLUMN as name from OSM_PREFIX_landusages_gen0)\
             as foo using unique osm_id using srid=OSM_SRID"',
       9:'"geometry from (select geometry ,osm_id, type, OSM_NAME_COLUMN as name from OSM_PREFIX_landusages_gen1 \
-      where type in (\'forest\',\'industrial\',\'commercial\',\'residential\')) as foo using unique osm_id using srid=OSM_SRID"',
+      where type in (\'forest\',\'wood\',\'industrial\',\'commercial\',\'residential\')) as foo using unique osm_id using srid=OSM_SRID"',
       10:'"geometry from (select geometry ,osm_id, type, OSM_NAME_COLUMN as name from OSM_PREFIX_landusages_gen1 \
-      where type in (\'forest\',\'pedestrian\',\'cemetery\',\'industrial\',\'commercial\',\
+      where type in (\'forest\',\'wood\',\'pedestrian\',\'cemetery\',\'industrial\',\'commercial\',\
       \'brownfield\',\'residential\',\'school\',\'college\',\'university\',\
       \'military\',\'park\',\'golf_course\',\'hospital\',\'parking\',\'stadium\',\'sports_center\',\
       \'pitch\') order by area desc) as foo using unique osm_id using srid=OSM_SRID"',
       12:'"geometry from (select geometry ,osm_id, type, OSM_NAME_COLUMN as name from OSM_PREFIX_landusages \
-      where type in (\'forest\',\'pedestrian\',\'cemetery\',\'industrial\',\'commercial\',\
+      where type in (\'forest\',\'wood\',\'pedestrian\',\'cemetery\',\'industrial\',\'commercial\',\
       \'brownfield\',\'residential\',\'school\',\'college\',\'university\',\
       \'military\',\'park\',\'golf_course\',\'hospital\',\'parking\',\'stadium\',\'sports_center\',\
       \'pitch\') order by area desc) as foo using unique osm_id using srid=OSM_SRID"'
@@ -1288,18 +1288,18 @@ styles = {
       },
       'landusage_data': {
          0:'"way from (select way, osm_id, name, type from (select way, st_area(way) as area, osm_id, (case when landuse is not null then landuse else (case when \\\"natural\\\" is not null then \\\"natural\\\" else (case when leisure is not null then leisure else amenity end) end) end) as type, OSM_NAME_COLUMN as name from OSM_PREFIX_polygon) as osm2 \
-         where type in (\'forest\',\'residential\')\
+         where type in (\'forest\',\'wood\',\'residential\')\
          order by area desc) as foo using unique osm_id using srid=OSM_SRID"',
          6:'"way from (select way, osm_id, name, type from (select way , st_area(way) as area ,osm_id, (case when landuse is not null then landuse else (case when \\\"natural\\\" is not null then \\\"natural\\\" else (case when leisure is not null then leisure else amenity end) end) end) as type, OSM_NAME_COLUMN as name from OSM_PREFIX_polygon) as osm2 \
-         where type in (\'forest\',\'industrial\',\'commercial\',\'residential\')\
+         where type in (\'forest\',\'wood\',\'industrial\',\'commercial\',\'residential\')\
          order by area desc) as foo using unique osm_id using srid=OSM_SRID"',
          9:'"way from (select way, osm_id, name, type from (select way, st_area(way) as area ,osm_id, (case when landuse is not null then landuse else (case when \\\"natural\\\" is not null then \\\"natural\\\" else (case when leisure is not null then leisure else amenity end) end) end) as type, OSM_NAME_COLUMN as name from OSM_PREFIX_polygon) as osm2 \
-         where type in (\'forest\',\'pedestrian\',\'cemetery\',\'industrial\',\'commercial\',\
+         where type in (\'forest\',\'wood\',\'pedestrian\',\'cemetery\',\'industrial\',\'commercial\',\
          \'brownfield\',\'residential\',\'school\',\'college\',\'university\',\
          \'military\',\'park\',\'golf_course\',\'hospital\',\'parking\',\'stadium\',\'sports_center\',\
          \'pitch\') order by area desc) as foo using unique osm_id using srid=OSM_SRID"',
          12:'"way from (select way, osm_id, name, type from (select way , st_area(way) as area ,osm_id, (case when landuse is not null then landuse else (case when \\\"natural\\\" is not null then \\\"natural\\\" else (case when leisure is not null then leisure else amenity end) end) end) as type, OSM_NAME_COLUMN as name from OSM_PREFIX_polygon) as osm2 \
-         where type in (\'forest\',\'pedestrian\',\'cemetery\',\'industrial\',\'commercial\',\
+         where type in (\'forest\',\'wood\',\'pedestrian\',\'cemetery\',\'industrial\',\'commercial\',\
          \'brownfield\',\'residential\',\'school\',\'college\',\'university\',\
          \'military\',\'park\',\'golf_course\',\'hospital\',\'parking\',\'stadium\',\'sports_center\',\
          \'pitch\') order by area desc) as foo using unique osm_id using srid=OSM_SRID"'

--- a/imposm-mapping.py
+++ b/imposm-mapping.py
@@ -389,14 +389,14 @@ landusages_gen00 = GeneralizedTable(
     name = 'landusages_gen00',
     tolerance = meter_to_mapunit(500.0),
     origin = landusages,
-    where = "type='forest' and ST_Area(geometry)>%f" % sqr_meter_to_mapunit(10000000),
+    where = "type IN ('forest', 'wood') AND  and ST_Area(geometry)>%f" % sqr_meter_to_mapunit(10000000),
 )
 
 landusages_gen0 = GeneralizedTable(
     name = 'landusages_gen0',
     tolerance = meter_to_mapunit(200.0),
     origin = landusages,
-    where = "type='forest' and ST_Area(geometry)>%f" % sqr_meter_to_mapunit(5000000),
+    where = "type IN ('forest', 'wood') AND  and ST_Area(geometry)>%f" % sqr_meter_to_mapunit(5000000),
 )
 
 landusages_gen1 = GeneralizedTable(

--- a/imposm3-mapping.json
+++ b/imposm3-mapping.json
@@ -52,12 +52,12 @@
         },
         "landusages_gen0": {
             "source": "landusages_gen1",
-            "sql_filter": "ST_Area(geometry)>500000.000000",
+            "sql_filter": "type IN ('forest', 'wood') AND ST_Area(geometry)>500000.000000",
             "tolerance": 200.0
         },
 	"landusages_gen00": {
 	    "source": "landusages",
-	    "sql_filter": "ST_Area(geometry)>1000000.000000",
+	    "sql_filter": "type IN ('forest', 'wood') AND ST_Area(geometry)>1000000.000000",
 	    "tolerance": 500.0 
 	}
     },


### PR DESCRIPTION
Add `wood` to `landusage_data`, align mapping of imposm3 with imposm. As discussed on https://wiki.openstreetmap.org/wiki/Forest `natural=wood` and `landuse=forest` are both used for areas with trees and should be displayed like that. [landusage.map](https://github.com/mapserver/basemaps/blob/master/landusage.map#L20) already contains an according expression, but since `landusage_data` filters the queries on zoomlevels 9+ the `wood` areas are not displayed.