### PR TITLE
Use landusages_gen0 as source for landusages_gen00

### DIFF
--- a/imposm3-mapping.json
+++ b/imposm3-mapping.json
@@ -56,7 +56,7 @@
             "tolerance": 200.0
         },
         "landusages_gen00": {
-            "source": "landusages",
+            "source": "landusages_gen0",
             "sql_filter": "type IN ('forest', 'wood') AND ST_Area(geometry)>1000000.000000",
             "tolerance": 500.0
         }


### PR DESCRIPTION
Only records which are already included in `landusages_gen0` can qualify for `landusages_gen00`. The query to create the generalized table is much faster using the smaller resultset. (12s instead of 1m13s on my system).