### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CPP=gcc -E -x c
 #if the preprocessor fails for some reason, try replacing this with "cpp" on linux, or "cpp-4.2" on darwin (not available starting with mountain lion)
 
 
-OSM_PREFIX?=osm_new_
+OSM_PREFIX?=osm_
 OSM_NAME_COLUMN?=name
 #OSM_SRID?=4326
 #OSM_UNITS?=dd
@@ -23,6 +23,7 @@ OSM_FORCE_POSTGIS_EXTENT?=0
 OSM_WMS_SRS?=EPSG:900913 EPSG:4326 EPSG:3857 EPSG:2154 EPSG:310642901 EPSG:4171 EPSG:310024802 EPSG:310915814 EPSG:310486805 EPSG:310702807 EPSG:310700806 EPSG:310547809 EPSG:310706808 EPSG:310642810 EPSG:310642801 EPSG:310642812 EPSG:310032811 EPSG:310642813 EPSG:2986
 DEBUG?=1
 LAYERDEBUG?=1
+PROJ_LIB?=`pwd`
 STYLE?=default
 #can also use google or bing
 
@@ -39,7 +40,6 @@ includes=land.map landusage.map borders.map highways.map places.map \
 
 
 mapfile=osm-$(STYLE).map
-here=`pwd`
 
 all:$(mapfile) boundaries.sql
 
@@ -104,7 +104,7 @@ generated/$(STYLE)level18.msinc: generate_style.py
 	python generate_style.py  -s $(STYLE) -l 18 > $@
 
 $(mapfile):$(template) $(includes)
-	$(CPP) -D_debug=$(DEBUG) -D_layerdebug=$(LAYERDEBUG)  -DOSM_PREFIX=$(OSM_PREFIX) -DOSM_SRID=$(OSM_SRID) -DOSM_FORCE_POSTGIS_EXTENT=$(OSM_FORCE_POSTGIS_EXTENT) -P -o $(mapfile) $(template) -DTHEME=$(STYLE) -D_proj_lib=\"$(here)\" -Igenerated
+	$(CPP) -D_debug=$(DEBUG) -D_layerdebug=$(LAYERDEBUG)  -DOSM_PREFIX=$(OSM_PREFIX) -DOSM_SRID=$(OSM_SRID) -DOSM_FORCE_POSTGIS_EXTENT=$(OSM_FORCE_POSTGIS_EXTENT) -P -o $(mapfile) $(template) -DTHEME=$(STYLE) -D_proj_lib=\"$(PROJ_LIB)\" -Igenerated
 	$(SED) 's/##.*$$//g' $(mapfile)
 	$(SED) '/^ *$$/d' $(mapfile)
 	$(SED) -e 's/OSM_PREFIX_/$(OSM_PREFIX)/g' $(mapfile)


### PR DESCRIPTION
Recent versions of Imposm use "osm_" as a table prefix (cf. the Imposm3 tutorial https://imposm.org/docs/imposm3/latest/tutorial.html#writing) so the value is modified here.

The Proj4 epsg file location turned into a parameter (PROJ_LIB), the default value is left as `pwd` but this allows setting, say, the /usr/share/proj directory more easily.