### PR TITLE
Modify generate_style.py for Python3 compatibility

### DIFF
--- a/generate_style.py
+++ b/generate_style.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import argparse
+
 layer_suffixes = {
    0:0,
    1:1,
@@ -1316,10 +1318,6 @@ namedstyles = {
 
    }
 }
-
-import sys
-import argparse
-
 
 # these are the preconfigured styles that can be called when creating the final mapfile,
 # e.g. with `make STYLE=google`. This will create an osm-google.map mapfile

--- a/generate_style.py
+++ b/generate_style.py
@@ -1318,7 +1318,7 @@ styles = {
 }
 
 import sys
-from optparse import OptionParser
+import argparse
 
 
 # these are the preconfigured styles that can be called when creating the final mapfile,
@@ -1339,24 +1339,23 @@ style_aliases = {
 }
 
 
-parser = OptionParser()
-parser.add_option("-l", "--level", dest="level", type="int", action="store", default=-1,
+parser = argparse.ArgumentParser()
+parser.add_argument("-l", "--level", dest="level", type=int, action="store", default=-1,
                   help="generate file for level n")
-parser.add_option("-g", "--global", dest="full", action="store_true", default=False,
+parser.add_argument("-g", "--global", dest="full", action="store_true", default=False,
                   help="generate global include file")
-parser.add_option("-s", "--style",
-                  action="store", dest="style", default="default",
+parser.add_argument("-s", "--style", action="store", dest="style", default="default",
                   help="comma separated list of styles to apply (order is important)")
 
-(options, args) = parser.parse_args()
+args = parser.parse_args()
 
 items = vars.items()
-for namedstyle in style_aliases[options.style].split(','):
+for namedstyle in style_aliases[args.style].split(','):
    items = items + styles[namedstyle].items()
 
 style = dict(items)
 
-if options.full:
+if args.full:
    print "###### level 0 ######"
    for k,v in style.iteritems():
       if type(v) is dict:
@@ -1377,8 +1376,8 @@ if options.full:
          else:
             print "#define _%s%d %s"%(k,i,v)
 
-if options.level != -1:
-   level = options.level
+if args.level != -1:
+   level = args.level
    for k,v in style.iteritems():
       print "#undef _%s"%(k)
 

--- a/generate_style.py
+++ b/generate_style.py
@@ -1355,30 +1355,30 @@ for namedstyle in style_aliases[args.style].split(','):
 style = vars
 
 if args.full:
-   print "###### level 0 ######"
+   print("###### level 0 ######")
    for k, v in style.items():
       if isinstance(v, dict):
-         print "#define _{0}0 {1}".format(k, v[0])
+         print("#define _{0}0 {1}".format(k, v[0]))
       else:
-         print "#define _{0}0 {1}".format(k, v)
+         print("#define _{0}0 {1}".format(k, v))
 
 
    for i in range(1,19):
-      print
-      print "###### level {0} ######".format(i)
+      print('')
+      print("###### level {0} ######".format(i))
       for k, v in style.items():
          if isinstance(v, dict):
             if not i in v:
-               print "#define _{0}{1} _{0}{2}".format(k, i, i-1)
+               print("#define _{0}{1} _{0}{2}".format(k, i, i-1))
             else:
-               print "#define _{0}{1} {2}".format(k, i, v[i])
+               print("#define _{0}{1} {2}".format(k, i, v[i]))
          else:
-            print "#define _{0}{1} {2}".format(k, i, v)
+            print("#define _{0}{1} {2}".format(k, i, v))
 
 if args.level != -1:
    level = args.level
    for k, v in style.items():
-      print "#undef _{0}".format(k)
+      print("#undef _{0}".format(k))
 
    for k, v in style.items():
-      print "#define _{0} _{0}{1}".format(k, level)
+      print("#define _{0} _{0}{1}".format(k, level))

--- a/generate_style.py
+++ b/generate_style.py
@@ -1357,7 +1357,7 @@ style = vars
 if args.full:
    print "###### level 0 ######"
    for k,v in style.iteritems():
-      if type(v) is dict:
+      if isinstance(v, dict):
          print "#define _{0}0 {1}".format(k, v[0])
       else:
          print "#define _{0}0 {1}".format(k, v)
@@ -1367,7 +1367,7 @@ if args.full:
       print
       print "###### level {0} ######".format(i)
       for k,v in style.iteritems():
-         if type(v) is dict:
+         if isinstance(v, dict):
             if not v.has_key(i):
                print "#define _{0}{1} _{0}{2}".format(k, i, i-1)
             else:

--- a/generate_style.py
+++ b/generate_style.py
@@ -1356,7 +1356,7 @@ style = vars
 
 if args.full:
    print "###### level 0 ######"
-   for k,v in style.iteritems():
+   for k, v in style.items():
       if isinstance(v, dict):
          print "#define _{0}0 {1}".format(k, v[0])
       else:
@@ -1366,7 +1366,7 @@ if args.full:
    for i in range(1,19):
       print
       print "###### level {0} ######".format(i)
-      for k,v in style.iteritems():
+      for k, v in style.items():
          if isinstance(v, dict):
             if not i in v:
                print "#define _{0}{1} _{0}{2}".format(k, i, i-1)
@@ -1377,8 +1377,8 @@ if args.full:
 
 if args.level != -1:
    level = args.level
-   for k,v in style.iteritems():
+   for k, v in style.items():
       print "#undef _{0}".format(k)
 
-   for k,v in style.iteritems():
+   for k, v in style.items():
       print "#define _{0} _{0}{1}".format(k, level)

--- a/generate_style.py
+++ b/generate_style.py
@@ -1368,7 +1368,7 @@ if args.full:
       print "###### level {0} ######".format(i)
       for k,v in style.iteritems():
          if isinstance(v, dict):
-            if not v.has_key(i):
+            if not i in v:
                print "#define _{0}{1} _{0}{2}".format(k, i, i-1)
             else:
                print "#define _{0}{1} {2}".format(k, i, v[i])

--- a/generate_style.py
+++ b/generate_style.py
@@ -65,7 +65,7 @@ minscales = {
    18:0
 }
 
-vars= {
+style = {
    'layer_suffix':layer_suffixes,
    'maxscale':maxscales,
    'minscale':minscales,
@@ -1020,7 +1020,7 @@ vars= {
    'locality_clr': "200 200 200",
 }
 
-styles = {
+namedstyles = {
    'default': {},
    'outlined':{
       'display_motorway_outline': {
@@ -1350,9 +1350,7 @@ parser.add_argument("-s", "--style", action="store", dest="style", default="defa
 args = parser.parse_args()
 
 for namedstyle in style_aliases[args.style].split(','):
-   vars.update(styles[namedstyle].items())
-
-style = vars
+   style.update(namedstyles[namedstyle].items())
 
 if args.full:
    print("###### level 0 ######")
@@ -1363,7 +1361,7 @@ if args.full:
          print("#define _{0}0 {1}".format(k, v))
 
 
-   for i in range(1,19):
+   for i in range(1, 19):
       print('')
       print("###### level {0} ######".format(i))
       for k, v in style.items():

--- a/generate_style.py
+++ b/generate_style.py
@@ -1349,11 +1349,10 @@ parser.add_argument("-s", "--style", action="store", dest="style", default="defa
 
 args = parser.parse_args()
 
-items = vars.items()
 for namedstyle in style_aliases[args.style].split(','):
-   items = items + styles[namedstyle].items()
+   vars.update(styles[namedstyle].items())
 
-style = dict(items)
+style = vars
 
 if args.full:
    print "###### level 0 ######"

--- a/generate_style.py
+++ b/generate_style.py
@@ -1359,27 +1359,27 @@ if args.full:
    print "###### level 0 ######"
    for k,v in style.iteritems():
       if type(v) is dict:
-         print "#define _%s0 %s"%(k,v[0])
+         print "#define _{0}0 {1}".format(k, v[0])
       else:
-         print "#define _%s0 %s"%(k,v)
+         print "#define _{0}0 {1}".format(k, v)
 
 
    for i in range(1,19):
       print
-      print "###### level %d ######"%(i)
+      print "###### level {0} ######".format(i)
       for k,v in style.iteritems():
          if type(v) is dict:
             if not v.has_key(i):
-               print "#define _%s%d _%s%d"%(k,i,k,i-1)
+               print "#define _{0}{1} _{0}{2}".format(k, i, i-1)
             else:
-               print "#define _%s%d %s"%(k,i,v[i])
+               print "#define _{0}{1} {2}".format(k, i, v[i])
          else:
-            print "#define _%s%d %s"%(k,i,v)
+            print "#define _{0}{1} {2}".format(k, i, v)
 
 if args.level != -1:
    level = args.level
    for k,v in style.iteritems():
-      print "#undef _%s"%(k)
+      print "#undef _{0}".format(k)
 
    for k,v in style.iteritems():
-      print "#define _%s _%s%s"%(k,k,level)
+      print "#define _{0} _{0}{1}".format(k, level)


### PR DESCRIPTION
### Rationale
On Archlinux `python` points to Python3 but I can't be bothered to `sed -i -e 's/python/python2/g' Makefile generate_style.py`.
Also I need `generate_style.py` to work on a system where `python` is Python2.

### Modifications
Some are for deprecated or removed functions (optparse, iteritems, has_key).
Some are recommendations from PyLint (although I did not start on the spacing and indentation warnings!): `vars` renaming, isinstance, unused `sys` import.
`print` could be modified without needing `__future__`.

### Testing
I've not done much except checksumming the resulting mapfiles to make sure I generated the same one after each change.
As far performance is concerned (observed with `time -v make` on my system) there is no significant difference. A full run takes about 2 seconds (90% usr), with max RSS 17.5MiB on Python2, with or without these changes.
It runs at 1 second, same RSS with Python3.