### PR TITLE
Replace deprecated elements in imposm3 schema

### DIFF
--- a/imposm3-mapping.json
+++ b/imposm3-mapping.json
@@ -63,7 +63,7 @@
     },
     "tables": {
         "landusages": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -85,7 +85,7 @@
                     "key": null
                 },
                 {
-                    "type": "pseudoarea",
+                    "type": "webmerc_area",
                     "name": "area",
                     "key": null
                 },
@@ -224,7 +224,7 @@
             }
         },
         "buildings": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -254,7 +254,7 @@
             }
         },
         "places": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -316,7 +316,7 @@
             }
         },
         "transport_areas": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -353,7 +353,7 @@
             }
         },
         "admin": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -388,7 +388,7 @@
             }
         },
         "aeroways": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -419,7 +419,7 @@
             }
         },
         "waterways": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -456,7 +456,7 @@
             }
         },
         "barrierways": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -498,7 +498,7 @@
             }
         },
         "transport_points": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -549,7 +549,7 @@
             }
         },
         "amenities": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -586,7 +586,7 @@
             }
         },
         "barrierpoints": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -631,7 +631,7 @@
             }
         },
         "housenumbers_interpolated": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -681,7 +681,7 @@
             }
         },
         "roads": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -745,12 +745,9 @@
             ],
             "type": "linestring",
             "filters": {
-                "exclude_tags": [
-                    [
-                        "area",
-                        "yes"
-                    ]
-                ]
+                "reject": {
+                    "area": [ "yes" ]
+                }
             },
             "mappings": {
                 "railway": {
@@ -804,7 +801,7 @@
             }
         },
         "housenumbers": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -849,7 +846,7 @@
             }
         },
         "waterareas": {
-            "fields": [
+            "columns": [
                 {
                     "type": "id",
                     "name": "osm_id",
@@ -871,7 +868,7 @@
                     "key": null
                 },
                 {
-                    "type": "pseudoarea",
+                    "type": "webmerc_area",
                     "name": "area",
                     "key": null
                 }


### PR DESCRIPTION
Per current imposm3 code:
https://github.com/omniscale/imposm3/blob/5816161a40f24446c1cebfe2c2158d6a2e5a3d8c/example-mapping.json

* `pseudoarea` deprecated end of 2016, replaced with `webmerc_area`
* `exclude_tags` deprecated beginning of 2017, replaced with `reject`
* `fields` deprecated end of 2017, replaced with `columns`