### PR TITLE
Fix OSM download URLs

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -17,11 +17,11 @@ simplified_land_polygons.shp: simplified-land-polygons-complete-3857.zip
 
 .INTERMEDIATE: simplified-land-polygons-complete-3857.zip
 simplified-land-polygons-complete-3857.zip:
-	wget http://data.openstreetmapdata.com/simplified-land-polygons-complete-3857.zip
+	wget http://osmdata.openstreetmap.de/download/simplified-land-polygons-complete-3857.zip
 
 land_polygons.shp: land-polygons-split-3857.zip
 	unzip -o -D -j land-polygons-split-3857.zip
 
 .INTERMEDIATE: land-polygons-split-3857.zip
 land-polygons-split-3857.zip:
-	wget http://data.openstreetmapdata.com/land-polygons-split-3857.zip
+	wget http://osmdata.openstreetmap.de/download/land-polygons-split-3857.zip


### PR DESCRIPTION
The OSM download URLs have changed, new base is https://osmdata.openstreetmap.de/download.