### PR TITLE
Match landuse mapped tag priority to imposm2 mapping

### DIFF
--- a/imposm3-mapping.json
+++ b/imposm3-mapping.json
@@ -145,55 +145,6 @@
             ],
             "type": "polygon",
             "mapping": {
-                "amenity": [
-                    "university",
-                    "school",
-                    "college",
-                    "library",
-                    "fuel",
-                    "parking",
-                    "cinema",
-                    "theatre",
-                    "place_of_worship",
-                    "hospital"
-                ],
-                "barrier": [
-                    "hedge"
-                ],
-                "leisure": [
-                    "park",
-                    "garden",
-                    "playground",
-                    "golf_course",
-                    "sports_centre",
-                    "pitch",
-                    "stadium",
-                    "common",
-                    "nature_reserve"
-                ],
-                "tourism": [
-                    "zoo"
-                ],
-                "natural": [
-                    "wood",
-                    "land",
-                    "scrub",
-                    "wetland",
-                    "heath"
-                ],
-                "man_made": [
-                    "pier"
-                ],
-                "aeroway": [
-                    "runway",
-                    "taxiway"
-                ],
-                "place": [
-                    "island"
-                ],
-                "military": [
-                    "barracks"
-                ],
                 "landuse": [
                     "park",
                     "forest",
@@ -216,9 +167,58 @@
                     "allotments",
                     "quarry"
                 ],
+                "leisure": [
+                    "park",
+                    "garden",
+                    "playground",
+                    "golf_course",
+                    "sports_centre",
+                    "pitch",
+                    "stadium",
+                    "common",
+                    "nature_reserve"
+                ],
+                "natural": [
+                    "wood",
+                    "land",
+                    "scrub",
+                    "wetland",
+                    "heath"
+                ],
                 "highway": [
                     "pedestrian",
                     "footway"
+                ],
+                "amenity": [
+                    "university",
+                    "school",
+                    "college",
+                    "library",
+                    "fuel",
+                    "parking",
+                    "cinema",
+                    "theatre",
+                    "place_of_worship",
+                    "hospital"
+                ],
+                "barrier": [
+                    "hedge"
+                ],
+                "tourism": [
+                    "zoo"
+                ],
+                "man_made": [
+                    "pier"
+                ],
+                "aeroway": [
+                    "runway",
+                    "taxiway"
+                ],
+                "place": [
+                    "island"
+                ],
+                "military": [
+                    "barracks"
                 ]
             }
         },


### PR DESCRIPTION
The [mapping order is important](https://imposm.org/docs/imposm3/latest/mapping.html#mapping-key) for the type mapping_value:

When using `imposm3-mapping.json` relation [9246043](https://www.openstreetmap.org/relation/9246043) with tags `landuse=forest,leisure=nature_reserve` got imported with `type=nature_reserve` and way [858830898](https://www.openstreetmap.org/way/858830898) with tags `landuse=forest,nature=scrub` got imported with `type=scrub`. 

With the imposm2 mapping these were imported as `type=forest` and only that type is rendered.

As far as I can tell other different tag orderings have no effect on rendering.