### PR TITLE
Optionally hide Label Outline

### DIFF
--- a/buildings.map
+++ b/buildings.map
@@ -38,8 +38,10 @@ LAYER
          MINFEATURESIZE AUTO
          SIZE _building_lbl_size
          COLOR _building_lbl_clr
+#if _label_outline_buildings == 1
          OUTLINECOLOR _building_lbl_ol_clr
          OUTLINEWIDTH _building_lbl_ol_width
+#endif
          WRAP ' '
          MAXLENGTH 6
          ALIGN CENTER

--- a/generate_style.py
+++ b/generate_style.py
@@ -90,6 +90,7 @@ style = {
       12: '"geometry from (select geometry,osm_id ,OSM_NAME_COLUMN as name,type from OSM_SCHEMA.OSM_PREFIX_waterareas) as foo using unique osm_id using srid=OSM_SRID"'
    },
    'display_waterarea_lbl' : {0:0, 6:1},
+   'display_waterarea_lbl_ol': 1,
    'display_waterarea_outline': {0:0, 14:1},
    'waterarea_opacity': 100,
    'waterarea_clr': '"#B3C6D4"',
@@ -124,6 +125,7 @@ style = {
       18:30
    },
    'display_canal_lbl' : {0:0, 10:1},
+   'display_canal_lbl_ol': 1,
    'canal_clr': '"#B3C6D4"',
    'canal_font': "sc",
    'canal_lbl_size': 8,
@@ -138,6 +140,7 @@ style = {
       14:2
    },
    'display_stream_lbl' : {0:0, 12:1},
+   'display_stream_lbl_ol': 1,
    'stream_clr': '"#B3C6D4"',
    'stream_font': "sc",
    'stream_lbl_size': 8,
@@ -159,6 +162,7 @@ style = {
       18:7
    },
    'display_river_lbl' : {0:0, 6:1},
+   'display_river_lbl_ol': 1,
    'river_clr': '"#B3C6D4"',
    'river_font': "sc",
    'river_lbl_size': {0:8,15:9,17:10},
@@ -197,6 +201,7 @@ style = {
    'industrial_ol_clr': '"#d1d1d1"',
    'industrial_ol_width': 0,
    'display_industrial_lbl' : {0:0, 11:1},
+   'display_industrial_lbl_ol': 1,
    'industrial_font': "sc",
    'industrial_lbl_size': 8,
    'industrial_lbl_clr': '0 0 0',
@@ -208,6 +213,7 @@ style = {
    'residential_ol_clr': '"#E3DED4"',
    'residential_ol_width': 0,
    'display_residential_lbl' : {0:0, 12:1},
+   'display_residential_lbl_ol': 1,
    'residential_font': "sc",
    'residential_lbl_size': 8,
    'residential_lbl_clr': '0 0 0',
@@ -217,6 +223,7 @@ style = {
    'display_park': 1,
    'park_clr': '"#DCDCB4"',
    'display_park_lbl' : {0:0, 11:1},
+   'display_park_lbl_ol': 1,
    'park_font': "sc",
    'park_lbl_size': 8,
    'park_lbl_clr': '0 0 0',
@@ -226,6 +233,7 @@ style = {
    'display_hospital': 1,
    'hospital_clr': '"#E6C8C3"',
    'display_hospital_lbl' : {0:0, 12:1},
+   'display_hospital_lbl_ol': 1,
    'hospital_font': "sc",
    'hospital_lbl_size': 8,
    'hospital_lbl_clr': '0 0 0',
@@ -235,6 +243,7 @@ style = {
    'display_education': 1,
    'education_clr': '"#DED1AB"',
    'display_education_lbl' : {0:0, 12:1},
+   'display_education_lbl_ol': 1,
    'education_font': "sc",
    'education_lbl_size': 8,
    'education_lbl_clr': '0 0 0',
@@ -244,6 +253,7 @@ style = {
    'display_sports': 1,
    'sports_clr': '"#DED1AB"',
    'display_sports_lbl' : {0:0, 12:1},
+   'display_sports_lbl_ol': 1,
    'sports_font': "sc",
    'sports_lbl_size': 8,
    'sports_lbl_clr': '0 0 0',
@@ -253,6 +263,7 @@ style = {
    'display_cemetery': 1,
    'cemetery_clr': '"#d1d1d1"',
    'display_cemetery_lbl' : {0:0, 12:1},
+   'display_cemetery_lbl_ol': 1,
    'cemetery_font': "sc",
    'cemetery_lbl_size': 8,
    'cemetery_lbl_clr': '0 0 0',
@@ -262,6 +273,7 @@ style = {
    'display_forest': 1,
    'forest_clr': '"#C2D1B2"',
    'display_forest_lbl' : {0:0, 12:1},
+   'display_forest_lbl_ol': 1,
    'forest_font': "sc",
    'forest_lbl_size': 8,
    'forest_lbl_clr': '0 0 0',
@@ -272,6 +284,7 @@ style = {
    'transport_opacity': 100,
    'transport_clr': '200 200 200',
    'display_transport_lbl' : {0:0, 12:1},
+   'display_transport_lbl_ol': 1,
    'transport_font': "sc",
    'transport_lbl_size': 8,
    'transport_lbl_clr': '0 0 0',
@@ -419,6 +432,7 @@ style = {
       0:0,
       13:1
    },
+   'label_outline_primaries': 1,
    'primary_font': "sc",
    'primary_lbl_size': {
       0:0,
@@ -461,6 +475,7 @@ style = {
       0:0,
       13:1
    },
+   'label_outline_secondaries': 1,
    'secondary_font': "sc",
    'secondary_lbl_size': {
       0:0,
@@ -498,6 +513,7 @@ style = {
       0:0,
       15:1
    },
+   'label_outline_tertiaries': 1,
    'tertiary_font': "sc",
    'tertiary_lbl_size': {
       0:0,
@@ -533,6 +549,7 @@ style = {
       0:0,
       15:1
    },
+   'label_outline_other_roads': 1,
    'other_font': "sc",
    'other_lbl_size': {
       0:0,
@@ -565,7 +582,9 @@ style = {
       0:0,
       15:1
    },
+   'label_outline_pedestrian': 1,
    'display_pedestrian_lbl' : {0:0, 15:1},
+   'display_pedestrian_lbl_ol': 1,
    'pedestrian_font': "sc",
    'pedestrian_lbl_size': {
       0:0,
@@ -600,6 +619,7 @@ style = {
       0:0,
       15:1
    },
+   'label_outline_track': 1,
    'track_font': "sc",
    'track_lbl_size': {
       0:0,
@@ -813,6 +833,7 @@ style = {
       0: 0,
       15: 1
    },
+   'label_outline_buildings': 1,
 
 
    ####### aeroways #######
@@ -861,6 +882,7 @@ style = {
    },
    'places_opacity': 100,
    'display_capitals': 0,
+   'display_capitals_outline': 1,
    'display_capital_symbol': {
       0:1,
       10:0
@@ -888,6 +910,7 @@ style = {
       0:1,
       3:0
    },
+   'display_continents_outline': 1,
    'continent_lbl_size': 8,
    'continent_lbl_clr': "100 100 100",
    'continent_lbl_ol_width': "1",
@@ -899,6 +922,7 @@ style = {
       2:1,
       8:0
    },
+   'display_countries_outline': 1,
    'country_lbl_size': 8,
    'country_lbl_clr': "100 100 100",
    'country_lbl_ol_width': 2,
@@ -910,6 +934,7 @@ style = {
       3:1,
       16:0
    },
+   'display_cities_outline': 1,
    'display_city_symbol': {
       0:1,
       10:0
@@ -947,6 +972,7 @@ style = {
       0:0,
       8:1
    },
+   'display_towns_outline': 1,
    'display_town_symbol': {
       0:1,
       12:0
@@ -977,6 +1003,7 @@ style = {
       0:0,
       13:1
    },
+   'display_suburbs_outline': 1,
    'suburb_font': "sc",
    'suburb_lbl_clr': {
       0:'"#444444"',
@@ -998,6 +1025,7 @@ style = {
       0:0,
       11:1
    },
+   'display_villages_outline': 1,
    'display_village_symbol': {
       0:1,
       14:0
@@ -1027,6 +1055,7 @@ style = {
       0:0,
       13:1
    },
+   'display_hamlets_outline': 1,
    'hamlet_font': "sc",
    'hamlet_lbl_clr': {
       0:'"#444444"',
@@ -1048,6 +1077,7 @@ style = {
       0:0,
       13:1
    },
+   'display_localities_outline': 1,
    'locality_font': "sc",
    'locality_lbl_clr': {
       0:'"#444444"',

--- a/highways.map
+++ b/highways.map
@@ -98,8 +98,10 @@ LAYER
             REPEATDISTANCE 400
             ANGLE FOLLOW
             COLOR _other_lbl_clr
+#if _label_outline_other_roads == 1
             OUTLINECOLOR _other_lbl_ol_clr
             OUTLINEWIDTH _other_lbl_ol_width
+#endif
             ENCODING "UTF-8"
             MINFEATURESIZE AUTO
             BUFFER 3
@@ -145,8 +147,10 @@ LAYER
             REPEATDISTANCE 400
             ANGLE FOLLOW
             COLOR _track_lbl_clr
+#if _label_outline_track == 1
             OUTLINECOLOR _track_lbl_ol_clr
             OUTLINEWIDTH _track_lbl_ol_width
+#endif
             MINFEATURESIZE AUTO
             BUFFER 3
             ENCODING "UTF-8"
@@ -191,8 +195,10 @@ LAYER
             REPEATDISTANCE 400
             ANGLE FOLLOW
             COLOR _tertiary_lbl_clr
+#if _label_outline_tertiaries == 1
             OUTLINECOLOR _tertiary_lbl_ol_clr
             OUTLINEWIDTH _tertiary_lbl_ol_width
+#endif
             MINFEATURESIZE AUTO
             BUFFER 3
             ENCODING "UTF-8"
@@ -237,8 +243,10 @@ LAYER
             REPEATDISTANCE 400
             ANGLE FOLLOW
             COLOR _secondary_lbl_clr
+#if _label_outline_secondaries == 1
             OUTLINECOLOR _secondary_lbl_ol_clr
             OUTLINEWIDTH _secondary_lbl_ol_width
+#endif
             MINFEATURESIZE AUTO
             BUFFER 3
             ENCODING "UTF-8"
@@ -355,8 +363,10 @@ LAYER
             REPEATDISTANCE 400
             MINFEATURESIZE AUTO
             COLOR _primary_lbl_clr
+#if _label_outline_primaries == 1
             OUTLINECOLOR _primary_lbl_ol_clr
             OUTLINEWIDTH _primary_lbl_ol_width
+#endif
             ANGLE FOLLOW
             BUFFER 3
             ENCODING "UTF-8"
@@ -400,8 +410,10 @@ LAYER
             REPEATDISTANCE 400
             ANGLE FOLLOW
             COLOR _pedestrian_lbl_clr
+#if _label_outline_pedestrian == 1
             OUTLINECOLOR _pedestrian_lbl_ol_clr
             OUTLINEWIDTH _pedestrian_lbl_ol_width
+#endif
             MINFEATURESIZE AUTO
             BUFFER 3
             ENCODING "UTF-8"

--- a/landusage.map
+++ b/landusage.map
@@ -34,8 +34,10 @@ LAYER
          FONT _forest_font
          SIZE _forest_lbl_size
          COLOR _forest_lbl_clr
+#if _display_forest_lbl_ol==1
          OUTLINECOLOR _forest_lbl_ol_clr
          OUTLINEWIDTH _forest_lbl_ol_width
+#endif
          WRAP ' '
          MAXLENGTH 6
          ALIGN CENTER
@@ -59,8 +61,10 @@ LAYER
          FONT _residential_font
          SIZE _residential_lbl_size
          COLOR _residential_lbl_clr
+#if _display_residential_lbl_ol==1
          OUTLINECOLOR _residential_lbl_ol_clr
          OUTLINEWIDTH _residential_lbl_ol_width
+#endif
          WRAP ' '
          MAXLENGTH 6
          ALIGN CENTER
@@ -85,8 +89,10 @@ LAYER
        FONT _industrial_font
        SIZE _industrial_lbl_size
        COLOR _industrial_lbl_clr
+#if _display_industrial_lbl_ol==1
        OUTLINECOLOR _industrial_lbl_ol_clr
        OUTLINEWIDTH _pedestrian_lbl_ol_width
+#endif
        PRIORITY 2
        WRAP ' '
        MAXLENGTH 6
@@ -111,8 +117,10 @@ LAYER
           SIZE _park_lbl_size
        ENCODING "utf-8"
           COLOR _park_lbl_clr
+#if _display_park_lbl_ol==1
           OUTLINECOLOR _park_lbl_ol_clr
           OUTLINEWIDTH _park_lbl_ol_width
+#endif
           PRIORITY 2
           POSITION cc
           WRAP ' '
@@ -137,8 +145,10 @@ LAYER
        ENCODING "utf-8"
             SIZE _cemetery_lbl_size
             COLOR _cemetery_lbl_clr
+#if _display_cemetery_lbl_ol==1
             OUTLINECOLOR _cemetery_lbl_ol_clr
             OUTLINEWIDTH _cemetery_lbl_ol_width
+#endif
             PRIORITY 2
             WRAP ' '
             MAXLENGTH 6
@@ -159,8 +169,10 @@ LAYER
          FONT _pedestrian_font
          SIZE _pedestrian_lbl_size
          COLOR _pedestrian_lbl_clr
+#if _display_pedestrian_lbl_ol==1
          OUTLINECOLOR _pedestrian_lbl_ol_clr
          OUTLINEWIDTH _pedestrian_lbl_ol_width
+#endif
          WRAP ' '
          MAXLENGTH 6
          ALIGN CENTER
@@ -181,10 +193,12 @@ LAYER
           PARTIALS FALSE
           FONT _hospital_font
           SIZE _hospital_lbl_size
+          ENCODING "utf-8"
           COLOR _hospital_lbl_clr
+#if _display_hospital_lbl_ol==1
           OUTLINECOLOR _hospital_lbl_ol_clr
-       ENCODING "utf-8"
           OUTLINEWIDTH _hospital_lbl_ol_width
+#endif
           PRIORITY 1
           WRAP ' '
           MAXLENGTH 6
@@ -206,10 +220,12 @@ LAYER
           PARTIALS FALSE
           FONT _education_font
           SIZE _education_lbl_size
-       ENCODING "utf-8"
+          ENCODING "utf-8"
           COLOR _education_lbl_clr
+#if _display_education_lbl_ol==1
           OUTLINECOLOR _education_lbl_ol_clr
           OUTLINEWIDTH _education_lbl_ol_width
+#endif
           PRIORITY 1
           WRAP ' '
           MAXLENGTH 6
@@ -231,10 +247,12 @@ LAYER
         PARTIALS FALSE
         FONT _sports_font
         SIZE _sports_lbl_size
+        ENCODING "utf-8"
         COLOR _sports_lbl_clr
+#if _display_sports_lbl_ol==1
         OUTLINECOLOR _sports_lbl_ol_clr
-       ENCODING "utf-8"
         OUTLINEWIDTH _sports_lbl_ol_width
+#endif
         PRIORITY 1
         WRAP ' '
         MAXLENGTH 6
@@ -272,15 +290,17 @@ LAYER
       STYLE
          COLOR _transport_clr
       END
-#if _display_transports_lbl==1
+#if _display_transport_lbl==1
       LABEL
         TYPE TRUETYPE
         PARTIALS FALSE
         FONT _transport_font
         SIZE _transport_lbl_size
-        COLOR _stransport_lbl_clr
+        COLOR _transport_lbl_clr
+#if _display_transport_lbl_ol==1
         OUTLINECOLOR _transport_lbl_ol_clr
         OUTLINEWIDTH _transport_lbl_ol_width
+#endif
         PRIORITY 1
         WRAP ' '
         MAXLENGTH 6
@@ -344,10 +364,12 @@ LAYER
           FONT _waterarea_font
           MINDISTANCE 200
           SIZE _waterarea_lbl_size
+          ENCODING "utf-8"
           COLOR _waterarea_lbl_clr
-       ENCODING "utf-8"
+#if _display_waterarea_lbl_ol == 1
           OUTLINECOLOR _waterarea_lbl_ol_clr
           OUTLINEWIDTH _waterarea_lbl_ol_width
+#endif
           WRAP ' '
           MAXLENGTH 5
           ALIGN CENTER
@@ -394,8 +416,10 @@ LAYER
           MINDISTANCE 200
           SIZE _river_lbl_size
           COLOR _river_lbl_clr
+#if _display_river_lbl_ol == 1
           OUTLINECOLOR _river_lbl_ol_clr
           OUTLINEWIDTH _river_lbl_ol_width
+#endif
           REPEATDISTANCE 400
           ENCODING "utf-8"
           MINFEATURESIZE AUTO
@@ -419,8 +443,10 @@ LAYER
             REPEATDISTANCE 400
           SIZE _stream_lbl_size
           COLOR _stream_lbl_clr
+#if _display_stream_lbl_ol == 1
           OUTLINECOLOR _stream_lbl_ol_clr
           OUTLINEWIDTH _stream_lbl_ol_width
+#endif
           MINFEATURESIZE AUTO
        ENCODING "utf-8"
           ANGLE FOLLOW
@@ -441,10 +467,12 @@ LAYER
           MINDISTANCE 200
             REPEATDISTANCE 400
           SIZE _canal_lbl_size
+          ENCODING "utf-8"
           COLOR _canal_lbl_clr
-       ENCODING "utf-8"
+#if _display_canal_lbl_ol == 1
           OUTLINECOLOR _canal_lbl_ol_clr
           OUTLINEWIDTH _canal_lbl_ol_width
+#endif
           MINFEATURESIZE AUTO
           ANGLE FOLLOW
           BUFFER 3

--- a/places.map
+++ b/places.map
@@ -29,8 +29,10 @@ LAYER
    SIZE _capital_lbl_size
    ENCODING "utf-8"
    COLOR _capital_lbl_clr
+#if _display_capitals_outline == 1
    OUTLINECOLOR _capital_lbl_ol_clr
    OUTLINEWIDTH _capital_lbl_ol_width
+#endif
    WRAP ' '
    MAXLENGTH 8
    ALIGN CENTER
@@ -62,8 +64,10 @@ LAYER
    ENCODING "utf-8"
    SIZE _continent_lbl_size
    COLOR _continent_lbl_clr
+#if _display_continents_outline == 1
    OUTLINECOLOR _continent_lbl_ol_clr
    OUTLINEWIDTH _continent_lbl_ol_width
+#endif
    BUFFER 4
    PARTIALS FALSE
    POSITION cc
@@ -79,8 +83,10 @@ LAYER
    ENCODING "utf-8"
    SIZE _country_lbl_size
    COLOR _country_lbl_clr
+#if _display_countries_outline == 1
    OUTLINECOLOR _country_lbl_ol_clr
    OUTLINEWIDTH _country_lbl_ol_width
+#endif
    WRAP ' '
    MAXLENGTH 8
    ALIGN CENTER
@@ -99,8 +105,10 @@ LAYER
    ENCODING "utf-8"
    SIZE _city_lbl_size
    COLOR _city_lbl_clr
+#if _display_cities_outline == 1
    OUTLINECOLOR _city_lbl_ol_clr
    OUTLINEWIDTH _city_lbl_ol_width
+#endif
    WRAP ' '
    MAXLENGTH 8
    ALIGN CENTER
@@ -127,8 +135,10 @@ LAYER
    ENCODING "utf-8"
    SIZE _town_lbl_size
    COLOR _town_lbl_clr
+#if _display_towns_outline == 1
    OUTLINECOLOR _town_lbl_ol_clr
    OUTLINEWIDTH _town_lbl_ol_width
+#endif
    WRAP ' '
    MAXLENGTH 8
    ALIGN CENTER
@@ -156,8 +166,10 @@ LAYER
    ENCODING "utf-8"
    SIZE _suburb_lbl_size
    COLOR _suburb_lbl_clr
+#if _display_suburbs_outline == 1
    OUTLINECOLOR _suburb_lbl_ol_clr
    OUTLINEWIDTH _suburb_lbl_ol_width
+#endif
    WRAP ' '
    MAXLENGTH 8
    ALIGN CENTER
@@ -184,8 +196,10 @@ LAYER
    ENCODING "utf-8"
    SIZE _village_lbl_size
    COLOR _village_lbl_clr
+#if _display_villages_outline == 1
    OUTLINECOLOR _village_lbl_ol_clr
    OUTLINEWIDTH _village_lbl_ol_width
+#endif
    WRAP ' '
    MAXLENGTH 8
    ALIGN CENTER
@@ -212,8 +226,10 @@ LAYER
    ENCODING "utf-8"
    SIZE _hamlet_lbl_size
    COLOR _hamlet_lbl_clr
+#if _display_hamlets_outline == 1
    OUTLINECOLOR _hamlet_lbl_ol_clr
    OUTLINEWIDTH _hamlet_lbl_ol_width
+#endif
    WRAP ' '
    MAXLENGTH 8
    ALIGN CENTER
@@ -240,8 +256,10 @@ LAYER
    ENCODING "utf-8"
    SIZE _locality_lbl_size
    COLOR _locality_lbl_clr
+#if _display_localities_outline == 1
    OUTLINECOLOR _locality_lbl_ol_clr
    OUTLINEWIDTH _locality_lbl_ol_width
+#endif
    WRAP ' '
    MAXLENGTH 8
    ALIGN CENTER


### PR DESCRIPTION
Introduce options to optional hide label outlines. We used this in combination with high contrast colors.

Example with minimal possible outline width:

<img width="600" height="601" alt="labels-with-minimal-outline" src="https://github.com/user-attachments/assets/d89b7381-bf05-4b3c-a65e-1a03d7c5f373" />

Example without outline:

<img width="600" height="601" alt="labels-without-outline" src="https://github.com/user-attachments/assets/dbd0345b-30d8-4021-8790-f1e0f4ac1bc0" />

EDIT: add examples with enabled/disabled outline